### PR TITLE
Add timestamps

### DIFF
--- a/include/wrek_event.hrl
+++ b/include/wrek_event.hrl
@@ -1,0 +1,8 @@
+-record(wrek_event, {
+          timestamp = erlang:timestamp() :: erlang:timestamp(),
+          id        = undefined :: pos_integer() | {pos_integer(), pos_integer()},
+          type      = undefined :: atom() | {atom(), atom()},
+          msg       = undefined :: any()
+         }).
+-type wrek_event() :: #wrek_event{}.
+-export_type([wrek_event/0]).

--- a/src/wrek_event.erl
+++ b/src/wrek_event.erl
@@ -1,4 +1,5 @@
 -module(wrek_event).
+-include("wrek_event.hrl").
 
 -export([exec_output/3,
          wrek_done/2,
@@ -10,32 +11,32 @@
          vert_msg/3]).
 
 exec_output(Mgr, Id, Msg) ->
-    gen_event:notify(Mgr, {wrek, Id, exec, Msg}).
+    gen_event:notify(Mgr, #wrek_event{id = Id, type = exec, msg = Msg}).
 
 
 wrek_done(Mgr, Id) ->
-    gen_event:notify(Mgr, {wrek, Id, {wrek, done}}).
+    gen_event:notify(Mgr, #wrek_event{id = Id, type = {wrek, done}}).
 
 
 wrek_error(Mgr, Id, Msg) ->
-    gen_event:notify(Mgr, {wrek, Id, {wrek, error}, Msg}).
+    gen_event:notify(Mgr, #wrek_event{id = Id, type = {wrek, error}, msg = Msg}).
 
 
 wrek_msg(Mgr, Id, Msg) ->
-    gen_event:notify(Mgr, {wrek, Id, {wrek, msg}, Msg}).
+    gen_event:notify(Mgr, #wrek_event{id = Id, type = {wrek, msg}, msg = Msg}).
 
 
 wrek_start(Mgr, Id, Map) ->
-    gen_event:notify(Mgr, {wrek, Id, {wrek, start}, Map}).
+    gen_event:notify(Mgr, #wrek_event{id = Id, type = {wrek, start}, msg = Map}).
 
 
 vert_done(Mgr, Id, Res) ->
-    gen_event:notify(Mgr, {wrek, Id, {vert, done}, Res}).
+    gen_event:notify(Mgr, #wrek_event{id = Id, type = {vert, done}, msg = Res}).
 
 
 vert_start(Mgr, Id, Name, Module, Args) ->
-    gen_event:notify(Mgr, {wrek, Id, {vert, start}, {Name, Module, Args}}).
+    gen_event:notify(Mgr, #wrek_event{id = Id, type = {vert, start}, msg = {Name, Module, Args}}).
 
 
 vert_msg(Mgr, Id, Msg) ->
-    gen_event:notify(Mgr, {wrek, Id, {vert, msg}, Msg}).
+    gen_event:notify(Mgr, #wrek_event{id = Id, type = {vert, msg}, msg = Msg}).

--- a/test/wrek_test_handler.erl
+++ b/test/wrek_test_handler.erl
@@ -1,4 +1,5 @@
 -module(wrek_test_handler).
+-include("wrek_event.hrl").
 
 -export([handle_call/2,
          handle_event/2,
@@ -23,7 +24,7 @@ handle_call(_, State) ->
     {ok, ok, State}.
 
 
-handle_event({wrek, _, {wrek, error}, _}, State) ->
+handle_event(#wrek_event{type = {wrek, error}}, State) ->
     #state{
        caller = Caller,
        count = Count
@@ -31,7 +32,7 @@ handle_event({wrek, _, {wrek, error}, _}, State) ->
     Caller ! (Count + 1),
     remove_handler;
 
-handle_event({wrek, _, {wrek, done}}, State) ->
+handle_event(#wrek_event{type = {wrek, done}}, State) ->
     #state{
        caller = Caller,
        count = Count


### PR DESCRIPTION
I was making the mistake of calculating timestamps after receiving event
messages, which runs the risk of losing a lot of accuracy when the VM is under
heavy load.