### PR TITLE
Upkeep/use monotonic time

### DIFF
--- a/include/wrek_event.hrl
+++ b/include/wrek_event.hrl
@@ -1,5 +1,5 @@
 -record(wrek_event, {
-          timestamp = erlang:timestamp() :: erlang:timestamp(),
+          timestamp = erlang:monotonic_time() :: integer(),
           id        = undefined :: pos_integer() | {pos_integer(), pos_integer()},
           type      = undefined :: atom() | {atom(), atom()},
           msg       = undefined :: any()

--- a/src/wrek_event.erl
+++ b/src/wrek_event.erl
@@ -2,6 +2,8 @@
 -include("wrek_event.hrl").
 
 -export([exec_output/3,
+         time_diff/2,
+         time_diff/3,
          wrek_done/2,
          wrek_error/3,
          wrek_msg/3,
@@ -9,6 +11,20 @@
          vert_done/3,
          vert_start/5,
          vert_msg/3]).
+
+
+-spec time_diff(wrek_event(), wrek_event()) -> non_neg_integer().
+
+time_diff(E1, E2) ->
+    time_diff(E1, E2, microsecond).
+
+
+-spec time_diff(wrek_event(), wrek_event(), erlang:time_unit()) ->
+    non_neg_integer().
+
+time_diff(#wrek_event{timestamp = T1}, #wrek_event{timestamp = T2}, TimeUnit) ->
+    erlang:convert_time_unit(T2 - T1, native, TimeUnit).
+
 
 exec_output(Mgr, Id, Msg) ->
     gen_event:notify(Mgr, #wrek_event{id = Id, type = exec, msg = Msg}).

--- a/src/wrek_utils.erl
+++ b/src/wrek_utils.erl
@@ -8,6 +8,7 @@
          rmdir/1,
          sandbox/2]).
 
+
 -spec format_dag(digraph:graph()) -> string().
 
 format_dag(Dag) ->

--- a/test/wrek_tests.erl
+++ b/test/wrek_tests.erl
@@ -1,5 +1,6 @@
 -module(wrek_tests).
 -include_lib("eunit/include/eunit.hrl").
+-include("wrek_event.hrl").
 
 from_verts_ok_test() ->
     Verts = #{
@@ -127,6 +128,12 @@ event_bad_test() ->
     % {wrek, done} =
     % (3 * #ok_verts) + (4 * #bad_verts) + 2
     ?assertEqual((3 * maps:size(VertMap)) + 3, Count).
+
+
+event_time_diff_test() ->
+    E1 = #wrek_event{},
+    E2 = #wrek_event{},
+    ?assert(wrek_event:time_diff(E1, E2) >= 0).
 
 
 %% private


### PR DESCRIPTION
I ran into an issue where subtracting consecutive timestamp values in wrek_event records occasionally resulted in a negative value. It turns out using `erlang:timestamp/0` does not guarantee monotonicity. Following the example set [here](http://erlang.org/doc/apps/erts/time_correction.html#Dos_and_Donts), I switched to using `erlang:monotonic_time/0` for timestamps. I also added `wrek_event:time_diff/{2,3}` in order to provide a blessed way of comparing the time difference between wrek_events, and a unit test asserting that calling wrek_event:time_diff on two consecutive records results in a positive value being returned.