### PR TITLE
Upkeep/refactor

### DIFF
--- a/src/wrek.erl
+++ b/src/wrek.erl
@@ -38,12 +38,11 @@
 ]).
 
 -record(state, {
-    children     = #{}       :: #{pid() => any()},
-    dag          = undefined :: digraph:graph() | undefined,
     event_mgr    = undefined :: pid() | undefined,
     failure_mode = total     :: partial | total,
     id           = ?id()     :: dag_id(),
-    sandbox      = undefined :: file:filename_all() | undefined
+    sandbox      = undefined :: file:filename_all() | undefined,
+    wrek         = undefined :: wrek_t:t() | undefined
 }).
 
 -type state() :: #state{}.
@@ -84,15 +83,11 @@ code_change(_Req, _From, State) ->
 
 -spec handle_call(_, _, state()) -> {reply, _, state()} | {stop, _, state()}.
 
-handle_call({put_sandbox, Dir}, {From, _}, State) ->
-    #state{
-        children = #{From := Name},
-        dag = Dag
-    } = State,
-    {Name, Vert} = digraph:vertex(Dag, Name),
+handle_call({put_sandbox, Dir}, {From, _}, State = #state{wrek = Wrek}) ->
+    {ok, {Name, Vert}} = wrek_t:child(Wrek, From),
     Vert2 = wrek_vert_t:set_dir(Vert, Dir),
-    digraph:add_vertex(Dag, Name, Vert2),
-    {reply, ok, State};
+    Wrek2 = wrek_t:add_vertex(Wrek, Name, Vert2),
+    {reply, ok, State#state{wrek = Wrek2}};
 
 handle_call(sandbox, _From, State) ->
     {reply, State#state.sandbox, State};
@@ -109,39 +104,29 @@ handle_cast(_Req, State) ->
 
 -spec handle_info(_, state()) -> {noreply, state()}.
 
-handle_info({'EXIT', Pid, {shutdown, {ok, Data}}}, State0) ->
-    #state{
-        children = #{Pid := Name},
-        dag = Dag
-    } = State0,
+handle_info({'EXIT', Pid, {shutdown, {ok, Data}}}, State) ->
+    #state{wrek = Wrek} = State,
 
-    {Name, Vert} = digraph:vertex(Dag, Name),
-
-    Vert2 = wrek_vert_t:succeed(Vert, Data),
-    digraph:add_vertex(Dag, Name, Vert2),
-
-    State = remove_vert(State0, Pid),
-    start_verts_or_exit(State);
+    Wrek2 = wrek_t:child_succeeded(Wrek, Pid, Data),
+    start_verts_or_exit(State#state{wrek = Wrek2});
 
 handle_info({'EXIT', Pid, {shutdown, Reason}}, State) ->
     #state{
-       children = Children,
-       dag = Dag,
        event_mgr = EvMgr,
        failure_mode = FailMode,
-       id = Id
+       id = Id,
+       wrek = Wrek
       } = State,
-    #{Pid := Name} = Children,
+    {ok, {Name, _Vert}} = wrek_t:child(Wrek, Pid),
     wrek_event:wrek_error(EvMgr, Id, {vert, Name}),
     case FailMode of
         total ->
             {stop, {error, Reason}, State};
         partial ->
-            {Name, Vert} = digraph:vertex(Dag, Name),
-            digraph:add_vertex(Dag, Name, wrek_vert_t:fail(Vert, Reason)),
-            State2 = remove_vert(State, Pid),
-            propagate_partial_failure(State2, Name),
-            start_verts_or_exit(State)
+            Wrek2 = wrek_t:child_failed(Wrek, Pid, Reason),
+            State2 = State#state{wrek = Wrek2},
+            State3 = propagate_partial_failure(State2, Name),
+            start_verts_or_exit(State3)
     end;
 
 handle_info(_Req, State) ->
@@ -153,7 +138,7 @@ handle_info(_Req, State) ->
 init({Id, DagMap, Opts}) ->
     process_flag(trap_exit, true),
 
-    {ok, Dag} = wrek_utils:from_verts(DagMap),
+    {ok, Wrek} = wrek_t:from_verts(DagMap),
 
     EvMgr = proplists:get_value(event_manager, Opts, undefined),
     FailMode = proplists:get_value(failure_mode, Opts, total),
@@ -161,22 +146,23 @@ init({Id, DagMap, Opts}) ->
     Sandbox = make_dag_sandbox(Id),
 
     State = #state{
-        dag = Dag,
         event_mgr = EvMgr,
         failure_mode = FailMode,
         id = Id,
-        sandbox = Sandbox
+        sandbox = Sandbox,
+        wrek = Wrek
      },
 
     wrek_event:wrek_start(EvMgr, Id, DagMap),
 
     {ok, State2} = start_verts(State),
 
-    case maps:size(State2#state.children) of
-        0 ->
-            wrek_event:wrek_error(EvMgr, Id, {unable_to_start, DagMap}),
-            {stop, {unable_to_start, DagMap}};
-        _ ->
+    case wrek_t:is_active(State2#state.wrek) of
+        false ->
+            Reason = {unable_to_start, DagMap},
+            wrek_event:wrek_error(EvMgr, Id, Reason),
+            {stop, Reason};
+        true ->
             {ok, State2}
     end.
 
@@ -187,24 +173,6 @@ terminate(_Reason, _State) ->
     ok.
 
 %% private
-
--spec is_dag_done(state()) -> boolean().
-
-is_dag_done(#state{dag = Dag}) ->
-    Verts = [digraph:vertex(Dag, V) || V <- digraph:vertices(Dag)],
-    lists:all(fun({_Name, Vert}) ->
-        wrek_vert_t:is_finished(Vert)
-    end, Verts).
-
-
--spec is_vert_ready(digraph:graph(), digraph:vertex()) -> boolean().
-
-is_vert_ready(Dag, Name) ->
-    Deps = [digraph:vertex(Dag, V) || V <- wrek_utils:in_vertices(Dag, Name)],
-    lists:all(fun({_Name, Vert}) ->
-        wrek_vert_t:has_succeeded(Vert)
-    end, Deps).
-
 
 -define(DIRNAME,
         lists:flatten(
@@ -223,87 +191,62 @@ make_dag_sandbox(Id) ->
 
 -spec make_vert_data(state(), _) -> any().
 
-make_vert_data(#state{dag = Dag}, Name) ->
-    Reaching =
-        [digraph:vertex(Dag, V) || V <- digraph_utils:reaching([Name], Dag)],
-    maps:from_list(Reaching).
+make_vert_data(#state{wrek = Wrek}, Name) ->
+    Dependencies =
+        [wrek_t:vertex(Wrek, N) || N <- wrek_t:dependencies(Wrek, Name)],
+    maps:from_list([wrek_t:vertex(Wrek, Name) | Dependencies]).
 
 
--spec remove_vert(state(), pid()) -> state().
-
-remove_vert(State = #state{children = Children}, Pid) ->
-    Children2 = maps:remove(Pid, Children),
-    State#state{children = Children2}.
-
-
--spec propagate_partial_failure(state(), digraph:vertex()) -> ok.
+-spec propagate_partial_failure(state(), digraph:vertex()) -> state().
 
 propagate_partial_failure(State, Name) ->
     #state{
-      dag = Dag,
       event_mgr = EvMgr,
-      id = Id
+      id = Id,
+      wrek = Wrek
     } = State,
-    Reachable = digraph_utils:reachable_neighbours([Name], Dag),
-    Fun = fun(Vert) ->
-        {Vert, Label} = digraph:vertex(Dag, Vert),
-        Label2 = wrek_vert_t:set_status(Label, cancelled),
-        digraph:add_vertex(Dag, Vert, Label2),
-        wrek_event:wrek_msg(EvMgr, Id, {vert_cancelled, Vert}),
-        ok
-    end,
-    lists:foreach(Fun, Reachable).
-
-
--spec ready_verts(state()) -> [digraph:vertex()].
-
-ready_verts(#state{dag = Dag, children = Children}) ->
-    lists:filter(fun(Name) ->
-        {Name, Vert} = digraph:vertex(Dag, Name),
-        is_vert_ready(Dag, Name) andalso
-        not wrek_vert_t:is_finished(Vert) andalso
-        not lists:member(Name, maps:values(Children))
-    end, digraph:vertices(Dag)).
+    Wrek2 = lists:foldl(fun(VertName, Acc) ->
+        wrek_event:wrek_msg(EvMgr, Id, {vert_cancelled, VertName}),
+        wrek_t:cancel_vertex(Acc, VertName)
+    end, Wrek, wrek_t:dependants(Wrek, Name)),
+    State#state{wrek = Wrek2}.
 
 
 -spec start_verts(state()) -> {ok, state()} | {error, _}.
 
-start_verts(State = #state{children = Children}) ->
-    ReadyVerts = ready_verts(State),
-    Children2 =
-        lists:foldl(
-          fun(Name, Acc) ->
-              {ok, Pid} = start_vert(State, Name),
-              Acc#{Pid => Name}
-          end, Children, ReadyVerts),
-    State2 = State#state{children = Children2},
+start_verts(State = #state{wrek = Wrek}) ->
+    ReadyVerts = wrek_t:ready_verts(Wrek),
+    Wrek2 = lists:foldl(fun(Name, Acc) ->
+        {ok, Pid} = start_vert(State, Name),
+        wrek_t:child_started(Acc, Name, Pid)
+    end, Wrek, ReadyVerts),
+    State2 = State#state{wrek = Wrek2},
     {ok, State2}.
 
 
 -spec start_vert(state(), digraph:vertex()) -> {ok, pid()}.
 
-start_vert(State = #state{dag = Dag, id = DagId}, Name) ->
+start_vert(State, Name) ->
     #state{
-        dag = Dag,
         event_mgr = EventMgr,
-        id = DagId
+        id = DagId,
+        wrek = Wrek
     } = State,
     VertId = {DagId, ?id()},
-    {Name, Vert} = digraph:vertex(Dag, Name),
-    Vert2 = wrek_vert_t:set_id(Vert, VertId),
-    digraph:add_vertex(Dag, Name, Vert2),
+    Wrek2 = wrek_t:set_vert_id(Wrek, Name, VertId),
+    {Name, Vert} = wrek_t:vertex(Wrek2, Name),
 
     wrek_event:wrek_msg(EventMgr, DagId, {starting_vert, VertId}),
 
     Data = make_vert_data(State, Name),
-    Args = {Vert2, Data, EventMgr, self()},
+    Args = {Vert, Data, EventMgr, self()},
     gen_server:start_link(wrek_vert, Args, []).
 
 
 -spec start_verts_or_exit(state()) -> {noreply, state()} | {stop, normal, state()}.
 
-start_verts_or_exit(State) ->
-    case is_dag_done(State) of
+start_verts_or_exit(State = #state{wrek = Wrek}) ->
+    case wrek_t:is_finished(Wrek) of
         true ->
             #state{
                 event_mgr = EvMgr,

--- a/src/wrek_t.erl
+++ b/src/wrek_t.erl
@@ -1,0 +1,292 @@
+-module(wrek_t).
+
+-export([
+    add_vertex/3,
+    cancel_vertex/2,
+    child/2,
+    child_failed/3,
+    child_started/3,
+    child_succeeded/3,
+    dependants/2,
+    dependencies/2,
+    edge/2,
+    edges/1,
+    is_active/1,
+    is_finished/1,
+    format/1,
+    from_verts/1,
+    ready_verts/1,
+    remove_child/2,
+    set_vert_id/3,
+    vertex/2,
+    vertices/1
+]).
+
+-type dag_t() :: digraph:graph().
+-type defn_t() :: wrek:vert_defn().
+-type edge_t() :: digraph:edge().
+-type label_t() :: digraph:label().
+-type name_t() :: any().
+-type vert_t() :: digraph:vertex().
+
+-record(t, {
+    children = #{}   :: #{pid() => vert_t()},
+    dag      = new() :: dag_t()
+}).
+
+-type t() :: #t{}.
+
+-export_type([
+    t/0
+]).
+
+
+-spec add_vertex(t(), vert_t(), wrek_vert_t:t()) -> t().
+
+add_vertex(T = #t{dag = Dag}, Name, Vert) ->
+    digraph:add_vertex(Dag, Name, Vert),
+    T.
+
+
+-spec cancel_vertex(t(), vert_t()) -> t().
+
+cancel_vertex(T = #t{}, Name) ->
+    {Name, Vert} = vertex(T, Name),
+    Vert2 = wrek_vert_t:cancel(Vert),
+    add_vertex(T, Name, Vert2).
+
+
+-spec child(t(), pid()) -> {ok, {vert_t(), wrek_vert_t:t()}} | false.
+
+child(T = #t{children = Children}, Pid) ->
+    case Children of
+        #{Pid := Name} ->
+            case vertex(T, Name) of
+                false ->
+                    false;
+                Vert ->
+                    {ok, Vert}
+            end;
+        _ ->
+            false
+    end.
+
+
+-spec child_failed(t(), pid(), any()) -> t().
+
+child_failed(T = #t{}, Pid, Reason) ->
+    {ok, {Name, Vert}} = child(T, Pid),
+    Vert2 = wrek_vert_t:fail(Vert, Reason),
+    T2 = add_vertex(T, Name, Vert2),
+    T3 = remove_child(T2, Pid),
+    T3.
+
+
+-spec child_started(t(), vert_t(), pid()) -> t().
+
+child_started(T = #t{children = Children}, Name, Pid) ->
+    Children2 = Children#{Pid => Name},
+    T#t{children = Children2}.
+
+
+-spec child_succeeded(t(), pid(), map()) -> t().
+
+child_succeeded(T = #t{}, Pid, Result) ->
+    {ok, {Name, Vert}} = child(T, Pid),
+    Vert2 = wrek_vert_t:succeed(Vert, Result),
+    T2 = add_vertex(T, Name, Vert2),
+    T3 = remove_child(T2, Pid),
+    T3.
+
+
+-spec dependants(t(), vert_t()) -> [vert_t()].
+
+dependants(#t{dag = Dag}, Name) ->
+    digraph_utils:reachable_neighbours([Name], Dag).
+
+
+-spec dependencies(t(), vert_t()) -> [vert_t()].
+
+dependencies(#t{dag = Dag}, Name) ->
+    digraph_utils:reaching_neighbours([Name], Dag).
+
+
+-spec edge(t(), vert_t()) -> {edge_t(), vert_t(), vert_t(), label_t()} | false.
+
+edge(#t{dag = Dag}, Edge) ->
+    digraph:edge(Dag, Edge).
+
+
+-spec edges(t()) -> [edge_t()].
+
+edges(#t{dag = Dag}) ->
+    digraph:edges(Dag).
+
+
+-spec format(t()) -> string().
+
+format(T = #t{}) ->
+    Verts = [vertex(T, V) || V <- vertices(T)],
+    Edges = [edge(T, E) || E <- edges(T)],
+    io_lib:format("~p~n", [{Verts, Edges}]).
+
+
+-spec from_verts(map() | [{name_t(), wrek:vert_map()}]) ->
+    {ok, t()} | {error, any()}.
+
+from_verts(Verts) when is_map(Verts) ->
+    from_verts(maps:to_list(Verts));
+
+from_verts(Proplist) ->
+    case make_vertices(Proplist) of
+        {ok, Verts} ->
+            T = #t{},
+            ok = add_vertices(T, Verts),
+            case add_dependencies(T, Verts) of
+                ok ->
+                    {ok, T};
+                {error, _} = Err ->
+                    Err
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+
+-spec is_active(t()) -> boolean().
+
+is_active(#t{children = Children}) ->
+    maps:size(Children) > 0.
+
+
+-spec is_finished(t()) -> boolean().
+
+is_finished(T) ->
+    lists:all(fun(VertName) ->
+        {VertName, Vert} = vertex(T, VertName),
+        wrek_vert_t:is_finished(Vert)
+    end, vertices(T)).
+
+
+-spec ready_verts(t()) -> [vert_t()].
+
+ready_verts(T = #t{dag = Dag, children = Children}) ->
+    lists:filter(fun(Name) ->
+        {Name, Vert} = vertex(T, Name),
+        is_vert_ready(T, Name) andalso
+        not wrek_vert_t:is_finished(Vert) andalso
+        not lists:member(Name, maps:values(Children))
+    end, digraph:vertices(Dag)).
+
+
+-spec remove_child(t(), pid()) -> t().
+
+remove_child(T = #t{children = Children}, Pid) ->
+    T#t{children = maps:remove(Pid, Children)}.
+
+
+-spec set_vert_id(t(), vert_t(), wrek:vert_id()) -> t().
+
+set_vert_id(T = #t{}, Name, Id) ->
+    {Name, Vert} = vertex(T, Name),
+    Vert2 = wrek_vert_t:set_id(Vert, Id),
+    add_vertex(T, Name, Vert2),
+    T.
+
+
+-spec vertex(t(), vert_t()) -> {vert_t(), label_t()} | false.
+
+vertex(#t{dag = Dag}, Vert) ->
+    digraph:vertex(Dag, Vert).
+
+
+-spec vertices(t()) -> [vert_t()].
+
+vertices(#t{dag = Dag}) ->
+    digraph:vertices(Dag).
+
+
+%% private
+
+-spec add_dependencies(t(), [wrek_vert_t:t()]) ->
+    ok | {error, any()}.
+
+add_dependencies(_T = #t{}, []) ->
+    ok;
+
+add_dependencies(T = #t{}, [Vert | Rest]) ->
+    Name = wrek_vert_t:name(Vert),
+    Deps = wrek_vert_t:deps(Vert),
+    case add_edges(T, Name, Deps) of
+        ok ->
+            add_dependencies(T, Rest);
+        {error, _} = Err ->
+            Err
+    end.
+
+
+-spec add_edges(t(), name_t(), [name_t()]) ->
+    ok | {error, any()}.
+
+add_edges(_T, _To, []) ->
+    ok;
+
+add_edges(T = #t{dag = Dag}, To, [From | Rest]) ->
+    case digraph:add_edge(Dag, From, To) of
+        {error, _} = Err ->
+            Err;
+        _ ->
+            add_edges(T, To, Rest)
+    end.
+
+
+-spec add_vertices(t(), [wrek_vert_t:t()]) -> ok.
+
+add_vertices(#t{dag = Dag}, Defns) ->
+    lists:foreach(fun(Vert) ->
+        Name = wrek_vert_t:name(Vert),
+        digraph:add_vertex(Dag, Name, Vert)
+    end, Defns).
+
+
+-spec is_vert_ready(t(), vert_t()) -> boolean().
+
+is_vert_ready(T, Name) ->
+    case vertex(T, Name) of
+        false ->
+            false;
+        {Name, Vert} ->
+            lists:all(fun(Dep) ->
+                {_, DepVert} = vertex(T, Dep),
+                wrek_vert_t:has_succeeded(DepVert)
+            end, wrek_vert_t:deps(Vert))
+    end.
+
+
+-spec make_vertices([{name_t(), defn_t()}]) ->
+    {ok, [wrek_vert_t:t()]} | {error, any()}.
+
+make_vertices(Verts) ->
+    make_vertices2(Verts, []).
+
+
+-spec make_vertices2([{name_t(), defn_t()}], [wrek_vert_t:t()]) ->
+    {ok, [wrek_vert_t:t()]} | {error, any()}.
+
+make_vertices2([], Acc) ->
+    {ok, Acc};
+
+make_vertices2([{Name, Defn} | Rest], Acc) ->
+    case wrek_vert_t:from_defn(Defn) of
+        {ok, Vert} ->
+            Vert2 = wrek_vert_t:set_name(Vert, Name),
+            make_vertices2(Rest, [Vert2 | Acc]);
+        {error, _} = Err ->
+            Err
+    end.
+
+
+-spec new() -> dag_t().
+
+new() ->
+    digraph:new([acyclic, protected]).

--- a/src/wrek_utils.erl
+++ b/src/wrek_utils.erl
@@ -107,10 +107,18 @@ add_edges(Dag, To, [From | Froms]) ->
     end.
 
 
--spec add_vertices(digraph:graph(), [{any(), wrek:vert_defn()}]) -> ok.
+-spec add_vertices(digraph:graph(), [{any(), wrek:vert_defn()}]) ->
+    ok | {error, any()}.
 
-add_vertices(Dag, Verts) ->
-    lists:foreach(
-      fun({Name, Defn}) -> digraph:add_vertex(Dag, Name, Defn) end,
-      Verts
-     ).
+add_vertices(_Dag, []) ->
+    ok;
+
+add_vertices(Dag, [{Name, Defn} | Rest]) ->
+    case wrek_vert_t:from_defn(Defn) of
+        {ok, Vert} ->
+            Vert2 = wrek_vert_t:set_name(Vert, Name),
+            digraph:add_vertex(Dag, Name, Vert2),
+            add_vertices(Dag, Rest);
+        {error, _} = Err ->
+            Err
+    end.

--- a/src/wrek_utils.erl
+++ b/src/wrek_utils.erl
@@ -1,48 +1,10 @@
 -module(wrek_utils).
 
--export([format_dag/1,
-         from_verts/1,
-         in_vertices/2,
-         out_vertices/2,
-         rm/1,
-         rmdir/1,
-         sandbox/2]).
-
-
--spec format_dag(digraph:graph()) -> string().
-
-format_dag(Dag) ->
-    Verts = [digraph:vertex(Dag, V) || V <- digraph:vertices(Dag)],
-    Edges = [digraph:edge(Dag, E) || E <- digraph:edges(Dag)],
-    io_lib:format("~p~n", [{Verts, Edges}]).
-
-
--spec from_verts(wrek:dag_map()) -> {ok, digraph:graph()} | {error, any()}.
-
-from_verts(Verts) when is_map(Verts) ->
-    from_verts(maps:to_list(Verts));
-
-from_verts(Verts) ->
-    Dag = digraph:new([acyclic, protected]),
-    add_vertices(Dag, Verts),
-    case add_dependencies(Dag, Verts) of
-        ok -> {ok, Dag};
-        {error, Reason} -> {error, Reason}
-    end.
-
-
--spec in_vertices(digraph:graph(), digraph:vertex()) -> [digraph:vertex()].
-
-in_vertices(Dag, Name) ->
-    InEdges = [digraph:edge(Dag, E) || E <- digraph:in_edges(Dag, Name)],
-    [V || {_, V, _, _} <- InEdges].
-
-
--spec out_vertices(digraph:graph(), digraph:vertex()) -> [digraph:vertex()].
-
-out_vertices(Dag, Name) ->
-    OutEdges = [digraph:edge(Dag, E) || E <- digraph:out_edges(Dag, Name)],
-    [V || {_, _, V, _} <- OutEdges].
+-export([
+    rm/1,
+    rmdir/1,
+    sandbox/2
+]).
 
 
 -spec rm(file:filename_all()) -> ok | {error, atom()}.
@@ -77,48 +39,3 @@ sandbox(BaseDir, Name) ->
     ok = filelib:ensure_dir(Dir),
     ok = file:make_dir(Dir),
     Dir.
-
-
-% private
-
--spec add_dependencies(digraph:graph(), [{atom(), wrek:vert_defn()}]) ->
-    ok | {error, any()}.
-
-add_dependencies(_Dag, []) ->
-    ok;
-
-add_dependencies(Dag, [{Name, #{deps := Deps}} | Vs]) ->
-    case add_edges(Dag, Name, Deps) of
-        ok -> add_dependencies(Dag, Vs);
-        {error, Reason} -> {error, Reason}
-    end.
-
-
--spec add_edges(digraph:graph(), digraph:vertex(), [digraph:vertex()]) ->
-    ok | {error, any()}.
-
-add_edges(_Dag, _To, []) ->
-    ok;
-
-add_edges(Dag, To, [From | Froms]) ->
-    case digraph:add_edge(Dag, From, To) of
-        {error, Reason} -> {error, Reason};
-        _ -> add_edges(Dag, To, Froms)
-    end.
-
-
--spec add_vertices(digraph:graph(), [{any(), wrek:vert_defn()}]) ->
-    ok | {error, any()}.
-
-add_vertices(_Dag, []) ->
-    ok;
-
-add_vertices(Dag, [{Name, Defn} | Rest]) ->
-    case wrek_vert_t:from_defn(Defn) of
-        {ok, Vert} ->
-            Vert2 = wrek_vert_t:set_name(Vert, Name),
-            digraph:add_vertex(Dag, Name, Vert2),
-            add_vertices(Dag, Rest);
-        {error, _} = Err ->
-            Err
-    end.

--- a/src/wrek_vert.erl
+++ b/src/wrek_vert.erl
@@ -1,30 +1,33 @@
 -module(wrek_vert).
 
--export([exec/3,
-         exec/4,
-         get/3,
-         get/4,
-         get_all/1,
-         get_sandbox/2,
-         make_sandbox/1,
-         notify/2]).
+-export([
+    exec/3,
+    exec/4,
+    get/3,
+    get/4,
+    get_all/1,
+    get_sandbox/2,
+    make_sandbox/1,
+    notify/2
+]).
 
 -behaviour(gen_server).
--export([code_change/3,
-         handle_call/3,
-         handle_cast/2,
-         handle_info/2,
-         init/1,
-         terminate/2]).
+-export([
+    code_change/3,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    init/1,
+    terminate/2
+]).
 
 -record(state, {
-          child     = undefined :: pid() | undefined,
-          data      = undefined :: map() | undefined,
-          event_mgr = undefined :: pid() | undefined,
-          id        = undefined :: {pos_integer(), pos_integer()} | undefined,
-          name      = undefined :: any() | undefined,
-          parent    = undefined :: pid() | undefined
-         }).
+    child     = undefined :: pid()                       | undefined,
+    data      = undefined :: #{any() => wrek_vert_t:t()} | undefined,
+    event_mgr = undefined :: pid()                       | undefined,
+    parent    = undefined :: pid()                       | undefined,
+    vert      = undefined :: wrek_vert_t:t()             | undefined
+}).
 -type state() :: #state{}.
 
 
@@ -90,59 +93,56 @@ code_change(_Req, _From, State) ->
 
 -spec handle_call(_, _, state()) -> {reply, fun(), state()}.
 
-handle_call({exec, Dir, Cmd, Env}, _From, State) ->
-    #state{
-       event_mgr = EvMgr,
-       id = Id
-      } = State,
+handle_call({exec, Dir, Cmd, Env}, _From, State = #state{event_mgr = EvMgr}) ->
     EventFun =
         fun(Msg) ->
-            wrek_event:exec_output(EvMgr, Id, Msg)
+            wrek_event:exec_output(EvMgr, id(State), Msg)
         end,
     Result = fun() -> wrek_exec:exec(Dir, Cmd, Env, EventFun) end,
     {reply, Result, State};
 
 handle_call({get, Who0, Key, Default}, _From, State) ->
-    #state{name = Name, data = Data} = State,
+    #state{data = Data, vert = MyVert} = State,
     Who = case Who0 of
-        me -> Name;
+        me -> name(MyVert);
         Other -> Other
     end,
 
     case Data of
-        #{Who := #{internal := #{Key := Val}}} ->
-            {reply, Val, State};
-        #{Who := #{Key := Val}} ->
-            {reply, Val, State};
+        #{Who := Vert} ->
+            case wrek_vert_t:kv(Vert) of
+                #{Key := Val} ->
+                    {reply, Val, State};
+                _ ->
+                    {reply, Default, State}
+            end;
         _ ->
             {reply, Default, State}
     end;
 
 handle_call(get_all, _From, #state{data = Data0}) ->
-    Data = maps:fold(fun(K, #{internal := V}, Acc) ->
-        Acc#{K => V}
+    Data = maps:fold(fun(Name, Vert, Acc) ->
+        D = wrek_vert_t:kv(Vert),
+        Acc#{Name => D}
     end, #{}, Data0),
     {reply, ok, Data};
 
 handle_call({get_sandbox, Who0}, _From, State) ->
-    #state{name = Name, data = Data} = State,
+    #state{data = Data} = State,
     Who = case Who0 of
-        me -> Name;
+        me -> name(State);
         Other -> Other
     end,
 
     case Data of
-        #{Who := #{dir := Dir}} ->
-            {reply, Dir, State};
+        #{Who := Vert} ->
+            {reply, wrek_vert_t:dir(Vert), State};
         _ ->
             {reply, undefined, State}
     end;
 
-handle_call(make_sandbox, _From, State) ->
-    #state{
-       id = {_DagId, VertId},
-       parent = Parent
-      } = State,
+handle_call(make_sandbox, _From, State = #state{parent = Parent}) ->
+    {_DagId, VertId} = id(State),
     DagDir = dag_dir(Parent),
     VertStr = integer_to_list(VertId),
     Dir = wrek_utils:sandbox(DagDir, VertStr),
@@ -155,12 +155,8 @@ handle_call(_Req, _From, State) ->
 
 -spec handle_cast(_, state()) -> {noreply, state()}.
 
-handle_cast({notify, Msg}, State) ->
-    #state{
-       event_mgr = EvMgr,
-       id = Id
-      } = State,
-    wrek_event:vert_msg(EvMgr, Id, Msg),
+handle_cast({notify, Msg}, State = #state{event_mgr = EvMgr}) ->
+    wrek_event:vert_msg(EvMgr, id(State), Msg),
     {noreply, State};
 
 handle_cast(_Req, State) ->
@@ -170,35 +166,34 @@ handle_cast(_Req, State) ->
 -spec handle_info(_, state()) ->
     {noreply, state()} | {stop, normal | {error, _}, state()}.
 
-handle_info(timeout, State) ->
-    #state{
-        event_mgr = EvMgr,
-        id = Id
-    } = State,
-    wrek_event:vert_done(EvMgr, Id, timeout),
+handle_info(timeout, State = #state{event_mgr = EvMgr}) ->
+    wrek_event:vert_done(EvMgr, id(State), timeout),
     {stop, {shutdown, timeout}, State};
 
-handle_info({'EXIT', _Pid, Term}, State) ->
-    #state{
-       event_mgr = EvMgr,
-       id = Id
-     } = State,
-    wrek_event:vert_done(EvMgr, Id, Term),
+handle_info({'EXIT', _Pid, Term}, State = #state{event_mgr = EvMgr}) ->
+    wrek_event:vert_done(EvMgr, id(State), Term),
     {stop, {shutdown, Term}, State};
 
 handle_info(_Req, State) ->
     {noreply, State}.
 
 
--spec init({map(), pid(), {pos_integer(), pos_integer()}, any(), pid()}) ->
+%% -spec init({map(), pid(), {pos_integer(), pos_integer()}, any(), pid()}) ->
+%%     {ok, state()}.
+
+-spec init({wrek_vert_t:t(), #{any() => wrek_vert_t:t()}, pid(), pid()}) ->
     {ok, state()}.
 
-init({Data, EventMgr, Id, Name, Parent}) ->
+init({Vert, Data, EventMgr, Parent}) ->
     process_flag(trap_exit, true),
-    #{Name := Map = #{module := Module, args := Args}} = Data,
 
-    case Map of
-        #{timeout := Ms} ->
+    Id = wrek_vert_t:id(Vert),
+    Name = wrek_vert_t:name(Vert),
+    Module = wrek_vert_t:module(Vert),
+    Args = wrek_vert_t:args(Vert),
+
+    case wrek_vert_t:timeout(Vert) of
+        Ms when is_integer(Ms) ->
             {ok, _TRef} = timer:send_after(Ms, timeout);
         _ -> ok
     end,
@@ -215,10 +210,9 @@ init({Data, EventMgr, Id, Name, Parent}) ->
         child = Pid,
         data = Data,
         event_mgr = EventMgr,
-        id = Id,
-        name = Name,
-        parent = Parent
-     },
+        parent = Parent,
+        vert = Vert
+    },
     {ok, State}.
 
 
@@ -234,3 +228,15 @@ terminate(_Reason, _State) ->
 
 dag_dir(Pid) ->
     gen_server:call(Pid, sandbox).
+
+
+-spec id(state()) -> wrek:vert_id().
+
+id(#state{vert = Vert}) ->
+    wrek_vert_t:id(Vert).
+
+
+-spec name(state()) -> any().
+
+name(#state{vert = Vert}) ->
+    wrek_vert_t:name(Vert).

--- a/src/wrek_vert.erl
+++ b/src/wrek_vert.erl
@@ -102,13 +102,12 @@ handle_call({exec, Dir, Cmd, Env}, _From, State = #state{event_mgr = EvMgr}) ->
     {reply, Result, State};
 
 handle_call({get, Who0, Key, Default}, _From, State) ->
-    #state{data = Data, vert = MyVert} = State,
     Who = case Who0 of
-        me -> name(MyVert);
+        me -> name(State);
         Other -> Other
     end,
 
-    case Data of
+    case State#state.data of
         #{Who := Vert} ->
             case wrek_vert_t:kv(Vert) of
                 #{Key := Val} ->

--- a/src/wrek_vert_t.erl
+++ b/src/wrek_vert_t.erl
@@ -1,0 +1,301 @@
+-module(wrek_vert_t).
+
+-export([
+    new/0,
+    cancel/1,
+    fail/2,
+    from_defn/1,
+    has_succeeded/1,
+    is_finished/1,
+    succeed/2,
+    % getters
+    args/1,
+    deps/1,
+    dir/1,
+    id/1,
+    kv/1,
+    module/1,
+    name/1,
+    reason/1,
+    status/1,
+    timeout/1,
+    % setters
+    set_args/2,
+    set_deps/2,
+    set_dir/2,
+    set_id/2,
+    set_kv/2,
+    set_module/2,
+    set_name/2,
+    set_reason/2,
+    set_status/2,
+    set_timeout/2
+]).
+
+-type args_t() :: list().
+-type deps_t() :: list().
+-type dir_t() :: file:filename_all() | undefined.
+-type id_t() :: wrek:vert_id() | undefined.
+-type kv_t() :: map().
+-type module_t() :: module() | undefined.
+-type name_t() :: any().
+-type reason_t() :: any().
+-type status_t() :: failed | done | cancelled | undefined.
+-type timeout_t() :: pos_integer() | undefined.
+
+-record(t, {
+    args    = []        :: args_t(),
+    deps    = []        :: deps_t(),
+    dir     = undefined :: dir_t(),
+    id      = undefined :: id_t(),
+    kv      = #{}       :: kv_t(),
+    module  = undefined :: module_t(),
+    name    = undefined :: name_t(),
+    reason  = undefined :: reason_t(),
+    status  = undefined :: status_t(),
+    timeout = undefined :: timeout_t()
+}).
+
+-type t() :: #t{}.
+
+-export_type([
+    t/0
+]).
+
+
+-spec new() -> t().
+
+new() ->
+    #t{}.
+
+
+-spec cancel(t()) -> t().
+
+cancel(Vert = #t{}) ->
+    set_status(Vert, cancelled).
+
+
+-spec fail(t(), reason_t()) -> t().
+
+fail(Vert = #t{}, Reason) ->
+    Vert2 = set_reason(Vert, Reason),
+    set_status(Vert2, failed).
+
+
+-spec from_defn(map()) -> {ok, t()} | {error, any()}.
+
+from_defn(Map0) when is_map(Map0) ->
+    Res0 = #t{},
+
+    MandatoryFields = [
+        {module, fun set_module/2},
+        {args, fun set_args/2},
+        {deps, fun set_deps/2}
+    ],
+
+    OptionalFields = [
+        {name, fun set_name/2},
+        {timeout, fun set_timeout/2}
+    ],
+
+    case load_mandatory(Res0, Map0, MandatoryFields) of
+        {error, _} = Err ->
+            Err;
+        {ok, {Res1, Map1}} ->
+            {ok, {Res2, Map2}} = load_optional(Res1, Map1, OptionalFields),
+            Res3 = set_kv(Res2, Map2),
+            {ok, Res3}
+    end;
+
+from_defn(_) ->
+    {error, not_a_map}.
+
+
+-spec has_succeeded(t()) -> boolean().
+
+has_succeeded(Vert = #t{}) ->
+    case status(Vert) of
+        done ->
+            true;
+        _ ->
+            false
+    end.
+
+
+-spec is_finished(t()) -> boolean().
+
+is_finished(Vert = #t{}) ->
+    case status(Vert) of
+        done ->
+            true;
+        failed ->
+            true;
+        cancelled ->
+            true;
+        _ ->
+            false
+    end.
+
+
+-spec succeed(t(), map()) -> t().
+
+succeed(Vert = #t{}, Result) ->
+    Vert2 = set_kv(Vert, Result),
+    set_status(Vert2, done).
+
+
+-spec args(t()) -> args_t().
+
+args(#t{args = Args}) ->
+    Args.
+
+
+-spec deps(t()) -> deps_t().
+
+deps(#t{deps = Deps}) ->
+    Deps.
+
+
+-spec dir(t()) -> dir_t().
+
+dir(#t{dir = Dir}) ->
+    Dir.
+
+
+-spec id(t()) -> id_t().
+
+id(#t{id = Id}) ->
+    Id.
+
+
+-spec kv(t()) -> kv_t().
+
+kv(#t{kv = Kv}) ->
+    Kv.
+
+
+-spec module(t()) -> module_t().
+
+module(#t{module = Module}) ->
+    Module.
+
+
+-spec name(t()) -> name_t().
+
+name(#t{name = Name}) ->
+    Name.
+
+
+-spec reason(t()) -> reason_t().
+
+reason(#t{reason = Reason}) ->
+    Reason.
+
+
+-spec status(t()) -> status_t().
+
+status(#t{status = Status}) ->
+    Status.
+
+
+-spec timeout(t()) -> timeout_t().
+
+timeout(#t{timeout = Timeout}) ->
+    Timeout.
+
+
+-spec set_args(t(), args_t()) -> t().
+
+set_args(T = #t{}, Args) ->
+    T#t{args = Args}.
+
+
+-spec set_deps(t(), deps_t()) -> t().
+
+set_deps(T = #t{}, Deps) ->
+    T#t{deps = Deps}.
+
+
+-spec set_dir(t(), dir_t()) -> t().
+
+set_dir(T = #t{}, Dir) ->
+    T#t{dir = Dir}.
+
+
+-spec set_id(t(), id_t()) -> t().
+
+set_id(T = #t{}, Id) ->
+    T#t{id = Id}.
+
+
+-spec set_kv(t(), kv_t()) -> t().
+
+set_kv(T = #t{}, Kv) ->
+    T#t{kv = Kv}.
+
+
+-spec set_module(t(), module_t()) -> t().
+
+set_module(T = #t{}, Module) ->
+    T#t{module = Module}.
+
+
+-spec set_name(t(), name_t()) -> t().
+
+set_name(T = #t{}, Name) ->
+    T#t{name = Name}.
+
+
+-spec set_reason(t(), reason_t()) -> t().
+
+set_reason(T = #t{}, Reason) ->
+    T#t{reason = Reason}.
+
+
+-spec set_status(t(), status_t()) -> t().
+
+set_status(T = #t{}, Status) ->
+    T#t{status = Status}.
+
+
+-spec set_timeout(t(), timeout_t()) -> t().
+
+set_timeout(T = #t{}, Timeout) ->
+    T#t{timeout = Timeout}.
+
+
+% private
+
+-type setter_t() :: fun((t(), any()) -> t()).
+
+-spec load_mandatory(t(), map(), [{atom(), setter_t()}]) ->
+    {ok, {t(), map()}} | {error, any()}.
+
+load_mandatory(Vert, Map, FieldSetterPairs) ->
+    load(Vert, Map, FieldSetterPairs, error).
+
+
+-spec load_optional(t(), map(), [{atom(), setter_t()}]) ->
+    {ok, {t(), map()}}.
+
+load_optional(Vert, Map, FieldSetterPairs) ->
+    load(Vert, Map, FieldSetterPairs, continue).
+
+
+-spec load(t(), map(), [{atom(), setter_t()}], error | continue) ->
+    {ok, {t(), map()}} | {error, any()}.
+
+load(Vert = #t{}, Map, [], _FailMode) ->
+    {ok, {Vert, Map}};
+
+load(Vert = #t{}, Map, [{FieldName, Setter} | Rest], FailMode) ->
+    case {Map, FailMode} of
+        {#{FieldName := FieldVal}, _} ->
+            Vert2 = Setter(Vert, FieldVal),
+            Map2 = maps:remove(FieldName, Map),
+            load(Vert2, Map2, Rest, FailMode);
+        {_, error} ->
+            {error, {missing_field, FieldName}};
+        {_, continue} ->
+            load(Vert, Map, Rest, FailMode)
+    end.

--- a/test/verts/wrek_get_vert.erl
+++ b/test/verts/wrek_get_vert.erl
@@ -1,0 +1,11 @@
+-module(wrek_get_vert).
+
+-behaviour(wrek_vert).
+
+-export([run/2]).
+
+run(Pairs, Pid) ->
+    Vals = lists:foldl(fun({Key, From}, Acc) ->
+        Acc#{From => wrek_vert:get(Pid, From, Key)}
+    end, #{}, Pairs),
+    {ok, Vals}.

--- a/test/verts/wrek_id_vert.erl
+++ b/test/verts/wrek_id_vert.erl
@@ -1,0 +1,9 @@
+-module(wrek_id_vert).
+
+-behaviour(wrek_vert).
+
+-export([run/2]).
+
+
+run([Arg], _Pid) ->
+    {ok, #{result => Arg}}.

--- a/test/wrek_tests.erl
+++ b/test/wrek_tests.erl
@@ -8,7 +8,9 @@ from_verts_ok_test() ->
       bar => ok_v([foo]),
       baz => ok_v([bar])
      },
-    {ok, Dag} = wrek_utils:from_verts(Verts),
+    {ok, Wrek} = wrek_t:from_verts(Verts),
+
+    Dag = element(3, Wrek),
 
     ?assertEqual([foo, bar, baz],
                  digraph_utils:topsort(Dag)).
@@ -20,13 +22,13 @@ from_verts_cycle_test() ->
       baz => ok_v([bar])
      },
     ?assertMatch({error, {bad_edge, _}},
-                 wrek_utils:from_verts(Cycle)).
+                 wrek_t:from_verts(Cycle)).
 
 from_verts_missing_dep_test() ->
-    Verts = #{bar => #{deps => [foo]}},
+    Verts = #{bar => ok_v([foo])},
 
     ?assertMatch({error, {bad_vertex, _}},
-                 wrek_utils:from_verts(Verts)).
+                 wrek_t:from_verts(Verts)).
 
 ok_test() ->
     error_logger:tty(false),


### PR DESCRIPTION
Fixes #8 

This PR comprises of two fairly large changes. I created modules that wrap record types for both vertices in a wrek DAG as well as the DAG itself. Now wrek.erl and wrek_vert.erl call the functions in wrek_t.erl and wrek_vert_t.erl to manipulate these records.