### PR TITLE
Accept wrek_vert_t:t() in wrek_vert_t:from_defn/1

### DIFF
--- a/src/wrek_vert_t.erl
+++ b/src/wrek_vert_t.erl
@@ -82,7 +82,7 @@ fail(Vert = #t{}, Reason) ->
     set_status(Vert2, failed).
 
 
--spec from_defn(map()) -> {ok, t()} | {error, any()}.
+-spec from_defn(map() | t()) -> {ok, t()} | {error, any()}.
 
 from_defn(Map0) when is_map(Map0) ->
     Res0 = #t{},
@@ -107,8 +107,11 @@ from_defn(Map0) when is_map(Map0) ->
             {ok, Res3}
     end;
 
+from_defn(T = #t{}) ->
+    {ok, T};
+
 from_defn(_) ->
-    {error, not_a_map}.
+    {error, not_map_or_record}.
 
 
 -spec has_succeeded(t()) -> boolean().


### PR DESCRIPTION
This fixes a bug where callers generate instances of wrek_vert_t:t() and pass them to
wrek:start/2, and wrek complains that it cannot convert the definitions to records.