### PR TITLE
Fix/get from kv

### DIFF
--- a/src/wrek_vert_t.erl
+++ b/src/wrek_vert_t.erl
@@ -142,8 +142,8 @@ is_finished(Vert = #t{}) ->
 
 -spec succeed(t(), map()) -> t().
 
-succeed(Vert = #t{}, Result) ->
-    Vert2 = set_kv(Vert, Result),
+succeed(Vert = #t{kv = Kv}, Result) ->
+    Vert2 = set_kv(Vert, maps:merge(Kv, Result)),
     set_status(Vert2, done).
 
 

--- a/test/wrek_tests.erl
+++ b/test/wrek_tests.erl
@@ -255,12 +255,13 @@ get_test() ->
     application:start(wrek),
 
     IdVerts = [1, 2, 3],
-    Pairs = [{result, From} || From <- IdVerts],
+    Pairs = [{result, From} || From <- IdVerts] ++ [{extra, 4}],
 
     VertMap = #{
       1 => id_v(1, []),
       2 => id_v(2, [1]),
       3 => id_v(3, [1]),
+      4 => #{module => wrek_true_vert, args => [], deps => [1], extra => 4},
       get => get_v(Pairs)
     },
 
@@ -292,7 +293,8 @@ get_test() ->
     GetExpect = #{
       1 => 1,
       2 => 2,
-      3 => 3
+      3 => 3,
+      4 => 4
     },
 
     ?assertMatch(#{1 := #{result := 1}}, ReturnVals),


### PR DESCRIPTION
`wrek_vert_t:succeed/2` would overwrite any KV pairs passed in through the definition of a vert. As a result, calling `wrek_vert:get/3` on one of these keys would fail.

I also renamed the records defined in `wrek_t` and `wrek_vert_t` to be `?MODULE` instead of `t`, making debugging much less confusing.

Thanks @fbernier for bringing this to my attention.