### PR TITLE
Add wrek_vert:reuse_sandbox/2 and test

### DIFF
--- a/src/wrek.app.src
+++ b/src/wrek.app.src
@@ -1,6 +1,6 @@
 {application, wrek,
  [{description, "An OTP application"},
-  {vsn, "2.0.2"},
+  {vsn, "3.1.0"},
   {registered, [wrek_sup]},
   {mod, {wrek_app, []}},
   {applications,

--- a/src/wrek.erl
+++ b/src/wrek.erl
@@ -48,7 +48,7 @@
 -type state() :: #state{}.
 
 
--spec put_sandbox(pid(), file:filename_all()) -> ok.
+-spec put_sandbox(pid(), file:filename_all()) -> {ok, wrek_vert_t:t()}.
 
 put_sandbox(Pid, Dir) ->
     gen_server:call(Pid, {put_sandbox, Dir}).
@@ -87,7 +87,7 @@ handle_call({put_sandbox, Dir}, {From, _}, State = #state{wrek = Wrek}) ->
     {ok, {Name, Vert}} = wrek_t:child(Wrek, From),
     Vert2 = wrek_vert_t:set_dir(Vert, Dir),
     Wrek2 = wrek_t:add_vertex(Wrek, Name, Vert2),
-    {reply, ok, State#state{wrek = Wrek2}};
+    {reply, {ok, Vert2}, State#state{wrek = Wrek2}};
 
 handle_call(sandbox, _From, State) ->
     {reply, State#state.sandbox, State};

--- a/src/wrek_vert_t.erl
+++ b/src/wrek_vert_t.erl
@@ -8,6 +8,7 @@
     has_succeeded/1,
     is_finished/1,
     succeed/2,
+    to_list/1,
     % getters
     args/1,
     deps/1,
@@ -147,6 +148,14 @@ is_finished(Vert = #?T{}) ->
 succeed(Vert = #?T{kv = Kv}, Result) ->
     Vert2 = set_kv(Vert, maps:merge(Kv, Result)),
     set_status(Vert2, done).
+
+
+-spec to_list(t()) -> [{atom(), any()}].
+
+to_list(T = #?T{}) ->
+    Fields = record_info(fields, ?T),
+    [_Tag | Values] = tuple_to_list(T),
+    lists:zip(Fields, Values).
 
 
 -spec args(t()) -> args_t().

--- a/test/verts/wrek_reuse_sandbox_vert.erl
+++ b/test/verts/wrek_reuse_sandbox_vert.erl
@@ -1,0 +1,10 @@
+-module(wrek_reuse_sandbox_vert).
+
+-behaviour(wrek_vert).
+
+-export([run/2]).
+
+run([Who], Pid) ->
+    {ok, Dir} = wrek_vert:reuse_sandbox(Pid, Who),
+    wrek_vert:notify(Pid, {dir, Dir}),
+    {ok, #{dir => Dir}}.

--- a/test/wrek_tests.erl
+++ b/test/wrek_tests.erl
@@ -308,7 +308,8 @@ sandbox_test() ->
     VertMap = #{
         1 => #{module => wrek_make_sandbox_vert, args => [], deps => []},
         2 => #{module => wrek_get_sandbox_vert, args => [1], deps => [1]},
-        3 => #{module => wrek_get_sandbox_vert, args => [1], deps => [2]}
+        3 => #{module => wrek_reuse_sandbox_vert, args => [1], deps => [1]},
+        4 => #{module => wrek_get_sandbox_vert, args => [3], deps => [3]}
     },
 
     {ok, EvMgr} = gen_event:start_link({local, wrek_test_manager}),
@@ -330,9 +331,8 @@ sandbox_test() ->
             Acc
     end, [], Msgs),
 
-    ?assertEqual(3, length(Notifs)),
-    ?assertEqual(lists:nth(1, Notifs), lists:nth(2, Notifs)),
-    ?assertEqual(lists:nth(2, Notifs), lists:nth(3, Notifs)).
+    ?assertEqual(4, length(Notifs)),
+    ?assertEqual(lists:usort(Notifs), [lists:nth(1, Notifs)]).
 
 custom_exec_callback_test() ->
     Self = self(),


### PR DESCRIPTION
I've been bitten by trying to `get_sandbox` a vert that doesn't call `make_sandbox`, but rather reuses another vert's sandbox. If that vert calls `reuse_sandbox` instead, I no longer have this problem.