### PR TITLE
Allowing wrek runner processes to stay alive

### DIFF
--- a/src/wrek_runner_sup.erl
+++ b/src/wrek_runner_sup.erl
@@ -11,8 +11,8 @@
 -spec start_link(Names :: list(atom())) -> {ok, pid()} | ignore | {error, term()}.
 
 start_link(Names) ->
-    {ok, Sup} = supervisor:start_link({local, ?SERVER}, ?MODULE, []),
-    [ supervisor:start_child(?MODULE,
+    {ok, Sup} = supervisor:start_link(?MODULE, []),
+    [ supervisor:start_child(Sup,
                              #{id => X,
                                start => {wrek_vert_runner, start_link, [#{stop_on_completion => false}]},
                                restart => temporary,

--- a/src/wrek_runner_sup.erl
+++ b/src/wrek_runner_sup.erl
@@ -1,0 +1,33 @@
+-module(wrek_runner_sup).
+
+-export([start_link/1]).
+
+-behaviour(supervisor).
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+
+-spec start_link(Names :: list(atom())) -> {ok, pid()} | ignore | {error, term()}.
+
+start_link(Names) ->
+    {ok, Sup} = supervisor:start_link({local, ?SERVER}, ?MODULE, []),
+    [ supervisor:start_child(?MODULE,
+                             #{id => X,
+                               start => {wrek_vert_runner, start_link, [#{stop_on_completion => false}]},
+                               restart => temporary,
+                               type => worker})
+      || X <- Names ],
+    {ok, Sup}.
+
+%% Callbacks
+
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+
+init([]) ->
+    SupFlags = #{
+      strategy => one_for_one,
+      intensity => 0,
+      period => 1
+     },
+    {ok, {SupFlags, []}}.

--- a/src/wrek_vert_runner.erl
+++ b/src/wrek_vert_runner.erl
@@ -1,0 +1,61 @@
+-module(wrek_vert_runner).
+
+-export([start_link/1,
+         set_stop_on_completion/2,
+         send_request/4,
+         check_response/2,
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+%% #{stop_on_completion => true (default) | false}
+-spec start_link(#{atom() => term()}) -> {ok, pid()}.
+start_link(Args) ->
+    gen_server:start_link(?MODULE, Args, []).
+
+-spec set_stop_on_completion(pid(), boolean()) -> ok.
+set_stop_on_completion(Pid, Flag) ->
+    gen_server:cast(Pid, {set, stop_on_completion, Flag}).
+
+-spec send_request(pid(), atom(), term(), pid()) -> term().
+send_request(Pid, Module, Args, Parent) ->
+    gen_server:send_request(Pid, {run, Module, Args, Parent}).
+
+-spec check_response(term(), term()) -> {reply, term()} | no_reply.
+check_response(Msg, RunId) ->
+    gen_server:check_response(Msg, RunId).
+
+-spec init(#{}) -> {ok, #{}}.
+init(#{}=Args) ->
+    {ok, Args}.
+
+-spec handle_call(term(), term(), map()) -> {stop, term(), term(), map()} | {reply, term(), map()}.
+handle_call({run, Module, Args, Parent}, _From, State) ->
+    Result = Module:run(Args, Parent),
+    case maps:get(stop_on_completion, State, true) of
+        true ->
+            Reason = Result,
+            {stop, Reason, Result, State};
+        false ->
+            {reply, Result, State}
+    end.
+
+-spec handle_cast({set, atom(), term()}, map()) -> {noreply, map()}.
+handle_cast({set, Key, Var}, State) ->
+    {noreply, State#{Key => Var}}.
+
+-spec handle_info(term(), map()) -> {noreply, map()}.
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+-spec terminate(term(), map()) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+-spec code_change(term(), map(), term()) -> {ok, map()}.
+code_change(_OldVsn, State, _Extras) ->
+    {ok, State}.
+

--- a/src/wrek_vert_runner.erl
+++ b/src/wrek_vert_runner.erl
@@ -37,8 +37,7 @@ handle_call({run, Module, Args, Parent}, _From, State) ->
     Result = Module:run(Args, Parent),
     case maps:get(stop_on_completion, State, true) of
         true ->
-            Reason = Result,
-            {stop, Reason, Result, State};
+            {stop, normal, Result, State};
         false ->
             {reply, Result, State}
     end.


### PR DESCRIPTION
Hello,

Thank you for writing wrek. It was very helpful in the creation of [Liet](https://github.com/relaypro-open/liet). Liet is a set of operations on a DAG (implemented via wrek) that was inspired by Terraform. It was written to solve the problem of creating complex test fixtures for eunit. However, it could have more general use cases.

There was one feature critical to Liet that I did not find in wrek, so I took the liberty to fork and make the changes contained in this PR. In short, we wanted Liet to be able to track resources that link themselves to Erlang processes, such as an ets table. Because wrek starts and stops a new process for each visited vertex, a resource created within that process will automatically be destroyed via process linking.

This PR allows a wrek a developer to optionally

a) keep 'runner' processes alive. This is accomplished by calling wrek:start_link instead of wrek:start.
b) use the same 'runner' process across several executions of the DAG, accomplished by providing the `runner_sup` option.

Admittedly, both of these are kind of clumsy from an API design perspective, so I'm open for discussion on how to make it more elegant/obvious. The PR is also missing any documentation. If you're interested in these features in the wrek mainline, I'd be happy to address both of these items.

Thanks,
Jesse